### PR TITLE
RM6690: initialize SPI in case of booting from EMMC

### DIFF
--- a/meta-msrzg2ul/recipes-bsp/trusted-firmware-a/trusted-firmware-a.bbappend
+++ b/meta-msrzg2ul/recipes-bsp/trusted-firmware-a/trusted-firmware-a.bbappend
@@ -7,5 +7,7 @@ FLASH_ADDRESS_FIP_msrzg2ul = "1D200"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-MSRZG2UL-board-configuration.patch"
+SRC_URI += "file://0001-MSRZG2UL-board-configuration.patch \
+            file://0001-Call-spi-init-during-EMMC-boot.patch \
+            "
 

--- a/meta-msrzg2ul/recipes-bsp/trusted-firmware-a/trusted-firmware-a/0001-Call-spi-init-during-EMMC-boot.patch
+++ b/meta-msrzg2ul/recipes-bsp/trusted-firmware-a/trusted-firmware-a/0001-Call-spi-init-during-EMMC-boot.patch
@@ -1,0 +1,28 @@
+From aac9d8be193c5e0352344e4a9ad560b031baeffb Mon Sep 17 00:00:00 2001
+From: Alexander Yurtsev <ay@aries-embedded.de>
+Date: Wed, 12 Jul 2023 18:25:20 +0000
+Subject: [PATCH] Call spi init during EMMC boot
+
+---
+ plat/renesas/rz/common/plat_storage.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/plat/renesas/rz/common/plat_storage.c b/plat/renesas/rz/common/plat_storage.c
+index c6a933009..b03ee2122 100755
+--- a/plat/renesas/rz/common/plat_storage.c
++++ b/plat/renesas/rz/common/plat_storage.c
+@@ -241,6 +241,7 @@ void rz_io_setup(void)
+ 				(uintptr_t) &emmc_block_spec,
+ 				&open_emmcdrv};
+ 		policies[FIP_IMAGE_ID] = emmc_fip_policy;
++		spi_multi_setup();
+ 	} else {
+ 		panic();
+ 	}
+@@ -262,4 +263,4 @@ int plat_get_image_source(unsigned int image_id, uintptr_t *dev_handle,
+ 	*dev_handle = *(policy->dev_handle);
+ 
+ 	return 0;
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
QSPI initialization is performed in the ATF in case it detects a boot from a QSPI flash. When the board boots from EMMC the SPI initialization is skipped. However, the MSRZG2UL module has both QSPI and EMMC installed on it, so for allowing both storages to be accessed simultaneously in U-Boot this change adds initialization of QSPI for the EMMC boot case.